### PR TITLE
Patch out the ME check that normally enables resetting the RTC.

### DIFF
--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -737,7 +737,6 @@ static void Task_TitleScreenPhase3(u8 taskId)
         SetMainCallback2(CB2_GoToClearSaveDataScreen);
     }
     else if (JOY_HELD(RESET_RTC_BUTTON_COMBO) == RESET_RTC_BUTTON_COMBO
-      && CanResetRTC() == TRUE)
     {
         FadeOutBGM(4);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_BLACK);


### PR DESCRIPTION
This change allows the player to reset the real-time clock by pressing `Left`+`SEL`+`B` on the title screen.