### PR TITLE
Cheaply acquired save space (thanks Hiram!)

### DIFF
--- a/include/save.h
+++ b/include/save.h
@@ -3,8 +3,8 @@
 
 // Each 4 KiB flash sector contains 3968 bytes of actual data followed by a 128 byte footer.
 // Only 12 bytes of the footer are used.
-#define SECTOR_DATA_SIZE 3968
-#define SECTOR_FOOTER_SIZE 128
+#define SECTOR_DATA_SIZE 4084
+#define SECTOR_FOOTER_SIZE 12
 #define SECTOR_SIZE (SECTOR_DATA_SIZE + SECTOR_FOOTER_SIZE)
 
 #define NUM_SAVE_SLOTS 2


### PR DESCRIPTION
This gives us an extra 116 bytes in SaveBlock2, an extra 464 bytes in SaveBlock1, and an extra 1044 bytes in PokemonStorage.