### PR TITLE
Faraway Island

### DIFF
--- a/data/maps/AlteringCave/scripts.inc
+++ b/data/maps/AlteringCave/scripts.inc
@@ -5,4 +5,21 @@ AlteringCave_MapScripts::
 AlteringCave_OnTransition:
 	setflag FLAG_LANDMARK_ALTERING_CAVE
 	end
+	
+AlteringCave_MysteryMan_Text_Preamble:
+	.string "???: Hello, child. I can take you to a\n"
+	.string "far-off land. Be warned: if you do not\l"
+	.string "bring POKé BALLS, you will be sorry.$"
 
+AlteringCave_MysteryMan_Text_NowGo:
+	.string "Now go ahead, and catch it!$"
+    
+AlteringCave_EventScript_MysteryMan::
+	lock
+	faceplayer
+	msgbox AlteringCave_MysteryMan_Text_Preamble, MSGBOX_AUTOCLOSE
+	fadescreen FADE_TO_BLACK
+	setflag FLAG_REMOVE_WARP_FADE
+	msgbox AlteringCave_MysteryMan_Text_NowGo, MSGBOX_AUTOCLOSE
+	warp MAP_FARAWAY_ISLAND_ENTRANCE, 0, 0, 0
+	end    	

--- a/data/maps/AlteringCave/scripts.inc
+++ b/data/maps/AlteringCave/scripts.inc
@@ -23,3 +23,4 @@ AlteringCave_EventScript_MysteryMan::
 	msgbox AlteringCave_MysteryMan_Text_NowGo, MSGBOX_AUTOCLOSE
 	warp MAP_FARAWAY_ISLAND_ENTRANCE, 0, 0, 0
 	end    	
+	

--- a/data/maps/FarawayIsland_Entrance/map.json
+++ b/data/maps/FarawayIsland_Entrance/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_NONE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": true,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/FarawayIsland_Entrance/map.json
+++ b/data/maps/FarawayIsland_Entrance/map.json
@@ -2,7 +2,7 @@
   "id": "MAP_FARAWAY_ISLAND_ENTRANCE",
   "name": "FarawayIsland_Entrance",
   "layout": "LAYOUT_FARAWAY_ISLAND_ENTRANCE",
-  "music": "MUS_ABANDONED_SHIP",
+  "music": "MUS_UNDERWATER",
   "region_map_section": "MAPSEC_FARAWAY_ISLAND",
   "requires_flash": false,
   "weather": "WEATHER_NONE",

--- a/data/maps/FarawayIsland_Interior/map.json
+++ b/data/maps/FarawayIsland_Interior/map.json
@@ -8,7 +8,7 @@
   "weather": "WEATHER_SHADE",
   "map_type": "MAP_TYPE_INDOOR",
   "allow_cycling": true,
-  "allow_escaping": false,
+  "allow_escaping": true,
   "allow_running": true,
   "show_map_name": true,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",

--- a/data/maps/FarawayIsland_Interior/map.json
+++ b/data/maps/FarawayIsland_Interior/map.json
@@ -2,7 +2,7 @@
   "id": "MAP_FARAWAY_ISLAND_INTERIOR",
   "name": "FarawayIsland_Interior",
   "layout": "LAYOUT_FARAWAY_ISLAND_INTERIOR",
-  "music": "MUS_ABANDONED_SHIP",
+  "music": "MUS_UNDERWATER",
   "region_map_section": "MAPSEC_FARAWAY_ISLAND",
   "requires_flash": false,
   "weather": "WEATHER_SHADE",


### PR DESCRIPTION
## Description
This change will reimplement Faraway Island, part of our quest to implement all 386 Pokémon into Tumbled.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Decapitalisation (e.g. changing `POKéMON` to `Pokémon`)
- [ ] Documentation (naming symbols, commenting, etc.)
- [ ] Style (code style refactors, typo, etc.)
- [x] Other: New feature

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] `make` and/or the `makerom` script outputs a playable ROM (`.gba` file).
- [x] I have sent the ROM mentioned above, along with the output `.elf` and `.map` files, to @fierymewtwo:matrix.org on **[matrix]**.
- [x] My code follows the [style guide](STYLE.md).

## **[matrix]** contact info
fierymewtwo:matrix.org
<!--- formatted as name:homeserver, e.g. fierymewtwo:matrix.org -->
<!--- Contributors must join https://matrix.to/#/#rebirthteam:matrix.org -->
