### PR TITLE
Debug menu shenanigans II: THE SEQUEL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,14 @@ jobs:
           ./install.sh ../
         working-directory: agbcc
 
-      - name: Modern
+      - name: Run "make modern"
         env:
           MODERN: 1
           COMPARE: 0
-        run: make -j${nproc} all
+        run: make -j${nproc}
+
+      - name: Debug testing (make DDEBUGGING=1)
+        env:
+          MODERN: 1
+          COMPARE: 0
+        run: make -j${nproc} DDEBUGGING=1

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,11 @@ ifeq ($(DINFO),1)
 override CFLAGS += -g
 endif
 
+ifeq ($(DDEBUGGING),1)
+override ASFLAGS += --defsym DEBUGGING=1
+override CPPFLAGS += -D DEBUGGING=1
+endif
+
 # The dep rules have to be explicit or else missing files won't be reported.
 # As a side effect, they're evaluated immediately instead of when the rule is invoked.
 # It doesn't look like $(shell) can be deferred so there might not be a better way.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,24 @@
 
 This is a decompilation of Pokémon Emerald, with many improvements and edits, similar to Rangi42's [polishedcrystal](https://github.com/Rangi42/polishedcrystal)
 
-It builds the following ROM:
+It builds the following ROMs:
 
-**tumbledemerald.gba**
+* **tumbledemerald.gba**
+* **tumbledemerald.gba** (debugging codebase)
 
-To set up the repository, see [INSTALL.md](INSTALL.md), or run either `makerom` (for apt) or `makerom_pacman` (for pacman) to compile automatically.
+To set up the repository, see [INSTALL.md](INSTALL.md), or run the appropriate script from the table below to compile automatically:
+
+|                                                                                     | You want a ROM for **debugging purposes** | You just want to **play** Tumbled |
+|-------------------------------------------------------------------------------------|-------------------------------------------|-----------------------------------|
+| If you use **Debian** or a derivative (**Ubuntu**, **Linux Mint**, **Linux Lite**   | Run `makerom`                             | Run `makerom_debug`               |
+| If you use an **Arch-based distro** (**Arch Linux**, **Manjaro**, **Garuda Linux**) | Run `makerom_pacman`                      | Run `makerom_pacman_debug`        |
 
 
-Here is the latest upstream commit (in 7-character shortened form) applied to `tumbledemerald`:
+Here is the last time `pret` / `master` was merged into `tumbledemerald` (`DD/MM/YYYY`):
 
-`Unknown`
+`20/12/2021`
+
+
 
 ## See also
 

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -3,6 +3,7 @@
 #include "bike.h"
 #include "coord_event_weather.h"
 #include "daycare.h"
+#include "debug.h"
 #include "faraway_island.h"
 #include "event_data.h"
 #include "event_object_movement.h"
@@ -132,6 +133,14 @@ void FieldGetPlayerInput(struct FieldInput *input, u16 newKeys, u16 heldKeys)
         input->dpadDirection = DIR_WEST;
     else if (heldKeys & DPAD_RIGHT)
         input->dpadDirection = DIR_EAST;
+    
+#if DEBUGGING
+    if ((heldKeys & R_BUTTON) && input->pressedStartButton)
+    {
+        input->input_field_1_2 = TRUE;
+        input->pressedStartButton = FALSE;
+    }
+#endif    
 }
 
 int ProcessPlayerFieldInput(struct FieldInput *input)
@@ -190,6 +199,15 @@ int ProcessPlayerFieldInput(struct FieldInput *input)
     }
     if (input->pressedSelectButton && UseRegisteredKeyItemOnField() == TRUE)
         return TRUE;
+    
+    #if DEBUGGING
+        if (input->input_field_1_2)
+        {
+            PlaySE(SE_WIN_OPEN);
+            Debug_ShowMainMenu();
+            return TRUE;
+        }
+    #endif
     
     if (input->pressedRButton && EnableAutoRun())
         return TRUE;


### PR DESCRIPTION
## Description
Re-add the debug menu, but this time it works.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Decapitalisation (e.g. changing `POKéMON` to `Pokémon`)
- [ ] Documentation (naming symbols, commenting, etc.)
- [ ] Style (code style refactors, typo, etc.)
- [x] New features (new mons, new graphics, new `something else here`
- [ ] Other: <!--- replace this comment with your type of change -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] `make` and/or the `makerom` script outputs a playable ROM (`.gba` file).
- [ ] I have sent the ROM mentioned above, along with the output `.elf` and `.map` files, to @fierymewtwo:matrix.org on **[matrix]**.
- [x] My code follows the [style guide](https://github.com/Rebirth-Devs/tumbledemerald/blob/master/STYLE.md).

## **[matrix]** contact info
<!--- formatted as name:homeserver, e.g. fierymewtwo:matrix.org -->
<!--- Contributors must join https://matrix.to/#/#rebirthteam:matrix.org -->
