### PR TITLE
Enable resetting the clock

### DIFF
--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -736,8 +736,7 @@ static void Task_TitleScreenPhase3(u8 taskId)
     {
         SetMainCallback2(CB2_GoToClearSaveDataScreen);
     }
-    else if (JOY_HELD(RESET_RTC_BUTTON_COMBO) == RESET_RTC_BUTTON_COMBO
-      && CanResetRTC() == TRUE)
+    else if (JOY_HELD(RESET_RTC_BUTTON_COMBO) == RESET_RTC_BUTTON_COMBO)
     {
         FadeOutBGM(4);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_BLACK);


### PR DESCRIPTION
## Description
This edit will allow the player to reset the in-game clock by holding `B`, `D-Pad Left`, and `Select` on the title screen. Most emulators feature a real time clock feature, but I want to play on my GBA. Deal with it.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Decapitalisation (e.g. changing `POKéMON` to `Pokémon`)
- [ ] Documentation (naming symbols, commenting, etc.)
- [ ] Style (code style refactors, typo, etc.)
- [x] New features (new mons, new graphics, new `something else here`
- [ ] Other: <!--- replace this comment with your type of change -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] `make` and/or the `makerom` script outputs a playable ROM (`.gba` file).
- [x] I have sent the ROM mentioned above, along with the output `.elf` and `.map` files, to @fierymewtwo:matrix.org on **[matrix]**.
- [x] My code follows the [style guide](https://github.com/Rebirth-Devs/tumbledemerald/blob/master/STYLE.md).

## **[matrix]** contact info
If you don't know, I'm not going to tell you.
<!--- formatted as name:homeserver, e.g. fierymewtwo:matrix.org -->
<!--- Contributors must join https://matrix.to/#/#rebirthteam:matrix.org -->
