### PR TITLE
(Hopefully) get evo moves working like in Gen 7

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -439,5 +439,6 @@ bool8 HasTwoFramesAnimation(u16 species);
 struct MonSpritesGfxManager *CreateMonSpritesGfxManager(u8 managerId, u8 mode);
 void DestroyMonSpritesGfxManager(u8 managerId);
 u8 *MonSpritesGfxManager_GetSpritePtr(u8 managerId, u8 spriteNum);
+u16 MonTryLearningNewMoveEvolution(struct Pokemon *mon, bool8 firstMove);
 
 #endif // GUARD_POKEMON_H

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -772,7 +772,7 @@ static void Task_EvolutionScene(u8 taskId)
     case EVOSTATE_TRY_LEARN_MOVE:
         if (!IsTextPrinterActive(0))
         {
-            var = MonTryLearningNewMove(mon, gTasks[taskId].tLearnsFirstMove);
+            var = MonTryLearningNewMoveEvolution(mon, gTasks[taskID].tLearnsFirstMove);
             if (var != MOVE_NONE && !gTasks[taskId].tEvoWasStopped)
             {
                 u8 text[20];
@@ -1193,7 +1193,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
     case T_EVOSTATE_TRY_LEARN_MOVE:
         if (!IsTextPrinterActive(0) && IsFanfareTaskInactive() == TRUE)
         {
-            var = MonTryLearningNewMove(mon, gTasks[taskId].tLearnsFirstMove);
+            var = MonTryLearningNewMoveEvolution(mon, gTasks[taskID].tLearnsFirstMove);
             if (var != MOVE_NONE && !gTasks[taskId].tEvoWasStopped)
             {
                 u8 text[20];

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2980,6 +2980,8 @@ void GiveBoxMonInitialMoveset(struct BoxPokemon *boxMon)
         u16 move;
 
         moveLevel = (gLevelUpLearnsets[species][i] & LEVEL_UP_MOVE_LV);
+        if (moveLevel == 0)
+            continue;
 
         if (moveLevel > (level << 9))
             break;
@@ -5439,6 +5441,34 @@ u8 GetNature(struct Pokemon *mon)
 u8 GetNatureFromPersonality(u32 personality)
 {
     return personality % NUM_NATURES;
+}
+
+u16 MonTryLearningNewMoveEvolution(struct Pokemon *mon, bool8 firstMove)
+{
+    u16 species = GetMonData(mon, MON_DATA_SPECIES, NULL);
+    u8 level = GetMonData(mon, MON_DATA_LEVEL, NULL);
+
+    // since you can learn more than one move per level
+    // the game needs to know whether you decided to
+    // learn it or keep the old set to avoid asking
+    // you to learn the same move over and over again
+    if (firstMove)
+    {
+        sLearningMoveTableID = 0;
+    }
+    while(gLevelUpLearnsets[species][sLearningMoveTableID] != LEVEL_UP_END)
+    {
+        u16 moveLevel;
+        moveLevel = (gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_MOVE_LV);
+        while (moveLevel == 0 || moveLevel == (level << 9))
+        {
+            gMoveToLearn = (gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_MOVE_ID);
+            sLearningMoveTableID++;
+            return GiveMoveToMon(mon, gMoveToLearn);
+        }
+        sLearningMoveTableID++;
+    }
+    return 0;
 }
 
 u16 GetEvolutionTargetSpecies(struct Pokemon *mon, u8 mode, u16 evolutionItem)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Decapitalisation (e.g. changing `POKéMON` to `Pokémon`)
- [ ] Documentation (naming symbols, commenting, etc.)
- [ ] Style (code style refactors, typo, etc.)
- [x] New features (new mons, new graphics, new `something else here`
- [ ] Other: <!--- replace this comment with your type of change -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] `make` and/or the `makerom` script outputs a playable ROM (`.gba` file).
- [ ] I have sent the ROM mentioned above, along with the output `.elf` and `.map` files, to @fierymewtwo:matrix.org on **[matrix]**.
- [x] My code follows the [style guide](https://github.com/Rebirth-Devs/tumbledemerald/blob/master/STYLE.md).

## **[matrix]** contact info
<!--- formatted as name:homeserver, e.g. fierymewtwo:matrix.org -->
<!--- Contributors must join https://matrix.to/#/#rebirthteam:matrix.org -->
